### PR TITLE
Fix highlight not working when popup is already open

### DIFF
--- a/docs/UTMap/setup.js
+++ b/docs/UTMap/setup.js
@@ -111,7 +111,11 @@ document.addEventListener("alpine:init", async () => {
     const html = `<div class="inspect-popup">${Array.from(Object.values(features)).map(feature2html).join("<br>")}</div>`;
     window.tigerMap.getSource("highlight").setData(newHighlightSource);
 
-    const popup = new maplibregl.Popup()
+    if(typeof(map._lastPopup) !== 'undefined' && map._lastPopup.isOpen()) {
+      map._lastPopup.off("close", onClose);
+    }
+
+    map._lastPopup = new maplibregl.Popup()
           .setLngLat(e.lngLat)
           .setHTML(html)
           .addTo(map)

--- a/docs/WAMap/setup.js
+++ b/docs/WAMap/setup.js
@@ -106,7 +106,11 @@ document.addEventListener("alpine:init", async () => {
     const html = `<div class="inspect-popup">${Array.from(Object.values(features)).map(feature2html).join("<br>")}</div>`;
     window.tigerMap.getSource("highlight").setData(newHighlightSource);
 
-    const popup = new maplibregl.Popup()
+    if(typeof(map._lastPopup) !== 'undefined' && map._lastPopup.isOpen()) {
+      map._lastPopup.off("close", onClose);
+    }
+
+    map._lastPopup = new maplibregl.Popup()
           .setLngLat(e.lngLat)
           .setHTML(html)
           .addTo(map)

--- a/docs/setup.js
+++ b/docs/setup.js
@@ -128,7 +128,11 @@ document.addEventListener("alpine:init", async () => {
     const html = `<div class="inspect-popup">${Array.from(Object.values(features)).map(feature2html).join("<br>")}</div>`;
     window.tigerMap.getSource("highlight").setData(newHighlightSource);
 
-    const popup = new maplibregl.Popup()
+    if(typeof(map._lastPopup) !== 'undefined' && map._lastPopup.isOpen()) {
+      map._lastPopup.off("close", onClose);
+    }
+
+    map._lastPopup = new maplibregl.Popup()
           .setLngLat(e.lngLat)
           .setHTML(html)
           .addTo(map)


### PR DESCRIPTION
I made a change to unhook the close event handler for the previous popup, when there is one, when opening a new popup. This keeps it from clearing the current highlight layer.