### PR TITLE
Add a filter to hide the points that aren't tagged

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,43 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload entire repository
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/WorldMap/main.js
+++ b/docs/WorldMap/main.js
@@ -166,8 +166,8 @@ function computeColor(value) {
       filterText = filterText.replace("(voronoi)","");
       addVoronoi(filterText)
     }
-    map.setPaintProperty ('allFeatures','line-color','#000000');
-    map.setPaintProperty ('allFeatures-node','circle-color','#000000');
+    map.setPaintProperty('allFeatures','line-color','#000000');
+    map.setPaintProperty('allFeatures-node','circle-color','#000000');
     map.setPaintProperty('osmcarto','raster-saturation',0)
 
     if (filterText === "") {
@@ -249,7 +249,9 @@ function computeColor(value) {
     }
 
     window.tigerMap.setFilter("allFeatures", filterArray)
-    window.tigerMap.setFilter("allFeatures-node", filterArray)
+    // Add the `@type=node` filter to the node layer
+    filterArray.push(["==", ["get", "@type"], "node"]);
+    window.tigerMap.setFilter("allFeatures-node", filterArray);
   }
   
   function clearFilter() {
@@ -263,7 +265,7 @@ function computeColor(value) {
 
     // modify the map layers
     window.tigerMap.setFilter("allFeatures", null);
-    window.tigerMap.setFilter("allFeatures-node", null);
+    window.tigerMap.setFilter("allFeatures-node", ["==", ["get", "@type"], "node"]);
 
     var filterTextBox = document.getElementById("filterTextBox");
     filterTextBox.value = "";

--- a/docs/WorldMap/mapstyle.js
+++ b/docs/WorldMap/mapstyle.js
@@ -9,7 +9,13 @@ var mapstyle_layers = [
     type: "line",
     paint: {
       "line-color": "#000000",
-      "line-width": 2,
+      "line-width": [
+        "interpolate",
+        ["linear"],
+        ["zoom"],
+        10, 0.1,
+        14, 2.5
+      ],
     },
     "layout": {
       "line-cap": "round",
@@ -24,7 +30,13 @@ var mapstyle_layers = [
     type: "circle",
     paint: {
       "circle-color": "#000000",
-      "circle-radius":4,
+      "circle-radius": [
+        "interpolate",
+        ["linear"],
+        ["zoom"],
+        10, 0,
+        14, 3
+      ],
     },
     "layout": {
       "visibility": "visible"

--- a/docs/WorldMap/mapstyle.js
+++ b/docs/WorldMap/mapstyle.js
@@ -31,7 +31,7 @@ var mapstyle_layers = [
     },
     source: "WAMap",
     "source-layer": "osm",
-    filter: ["==","$type","Point"]
+    filter: ["==", ["get", "@type"], "node"]
   },
   {
     id: "highlight",

--- a/docs/WorldMap/setup.js
+++ b/docs/WorldMap/setup.js
@@ -25,9 +25,9 @@ document.addEventListener("alpine:init", async () => {
       sources: {
         WAMap: {
           type: "vector",
-          tiles: ['https://random-geo-data.93b6cf.workers.dev/planet-240722/{z}/{x}/{y}.mvt'],
-          minzoom: 12,
-          maxzoom: 14,
+          tiles: ['https://random-geo-data.93b6cf.workers.dev/planet-240826/{z}/{x}/{y}.mvt'],
+          minzoom: 7,
+          maxzoom: 13,
           attribution: '© <a href="https://openstreetmap.org">OpenStreetMap</a>',
         },
         highlight: {


### PR DESCRIPTION
This makes a few changes:

* Add a filter (`["==", ["get", "@type"], "node"]`) that hides untagged points on the map
* Interpolate the line width and point size by zoom so that it's easier to see what's going on at lower zooms
* Switch to a tileset that has a wider zoom range (z7-z13)